### PR TITLE
Add audit to test CI, move react-scripts to devDependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -13,12 +13,13 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 14.x]
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm run lint
-    - run: npm test --if-present
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm run lint
+      - run: npm audit --production
+      - run: npm test --if-present

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react-feather": "^2.0.9",
     "react-middle-ellipsis": "^1.2.1",
     "react-router-dom": "^5.3.0",
-    "react-scripts": "^4.0.3",
     "react-tooltip": "^4.2.21",
     "styled-components": "^5.3.1",
     "styled-normalize": "^8.0.7"
@@ -33,6 +32,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "react-scripts": "^4.0.3",
     "typescript": "^4.4.3"
   },
   "scripts": {
@@ -40,8 +40,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --fix --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --fix --ext .ts,.tsx"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Even though the usefulness of `npm audit` is debated for front-end apps, let's use it to check our production dependencies.

Interesting reads: 
https://github.com/facebook/create-react-app/issues/11174
https://overreacted.io/npm-audit-broken-by-design/