### PR TITLE
Increase network switch visibility

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -11,6 +11,8 @@ interface MenuItem {
 
 type Direction = 'up' | 'down'
 
+const menuHeight = '47px'
+
 const Menu = ({
   label,
   icon,
@@ -26,7 +28,8 @@ const Menu = ({
 }) => {
   const [visible, setVisible] = useState(false)
 
-  const directionSign = direction === 'up' ? '-' : '+'
+  const animationOrigin = direction === 'up' ? '-95%' : `calc(${menuHeight} - 10px)`
+  const animationDestination = direction === 'up' ? '-100%' : menuHeight
 
   const handleBlur = () => {
     setVisible(false)
@@ -50,9 +53,9 @@ const Menu = ({
       <AnimatePresence>
         {visible && (
           <MenuItemsContainer
-            initial={{ y: `${directionSign}95%`, opacity: 0 }}
-            animate={{ y: `${directionSign}100%`, opacity: 1 }}
-            exit={{ y: `${directionSign}95%`, opacity: 0 }}
+            initial={{ y: animationOrigin, opacity: 0 }}
+            animate={{ y: animationDestination, opacity: 1 }}
+            exit={{ y: animationOrigin, opacity: 0 }}
             transition={{ duration: 0.15 }}
           >
             <MenuItemsList
@@ -77,8 +80,7 @@ const Menu = ({
 
 const MenuContainer = styled.div`
   position: relative;
-  height: 47px;
-  border-top: 1px solid ${({ theme }) => theme.borderSecondary};
+  height: ${menuHeight};
   display: flex;
 `
 
@@ -112,6 +114,7 @@ const MenuItemsContainer = styled(motion.div)`
   z-index: 10000;
   overflow: hidden;
   border-radius: 7px;
+  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.2);
 `
 
 const MenuItemsList = styled.div`

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -102,8 +102,6 @@ const Label = styled.span`
 `
 
 const IconContainer = styled.div`
-  width: 23px;
-  height: 23px;
   margin-right: 20px;
 `
 

--- a/src/components/NetworkLogo.tsx
+++ b/src/components/NetworkLogo.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components'
+
+import { NetworkType } from '..'
+
+interface NetworkLogoProps {
+  network: NetworkType
+  size?: number
+}
+
+const NetworkLogo = ({ network, size = 25 }: NetworkLogoProps) => {
+  return (
+    <LogoContainer network={network} size={size}>
+      {network === 'mainnet' ? 'M' : 'T'}
+    </LogoContainer>
+  )
+}
+
+const LogoContainer = styled.div<NetworkLogoProps>`
+  height: ${({ size }) => size}px;
+  width: ${({ size }) => size}px;
+  border-radius: 20%;
+  background: ${({ network, theme }) => (network === 'mainnet' ? theme.accentGradient : theme.bgSecondary)};
+  color: ${({ network, theme }) => (network === 'mainnet' ? 'rgba(255, 255, 255, 0.8)' : theme.textPrimary)};
+  border: 1px solid ${({ theme }) => theme.borderPrimary};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: normal;
+`
+
+export default NetworkLogo

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -147,7 +147,7 @@ const SearchInput = styled.input`
   &:active {
     box-shadow: 0 15px 15px rgba(0, 0, 0, 0.15);
     background: linear-gradient(${({ theme }) => `${theme.bgSecondary}, ${theme.bgSecondary}`}) padding-box,
-      /*this is your grey background*/ linear-gradient(to right, #6510f7, #f76110) border-box;
+      ${({ theme }) => theme.accentGradient};
     border: 1px solid transparent;
     z-index: 10;
   }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-import { useContext, useEffect, useRef } from 'react'
+import { useCallback, useContext, useEffect, useRef } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components'
 
@@ -49,6 +49,10 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
     }
   }
 
+  const closeSidebar = useCallback(() => {
+    setSidebarState('close')
+  }, [setSidebarState])
+
   useEffect(() => {
     if (windowWidth) {
       if (
@@ -57,17 +61,17 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
         windowWidth < deviceSizes.tablet &&
         open
       ) {
-        setSidebarState('close')
+        closeSidebar()
       }
 
       lastWindowWidth.current = windowWidth
     }
-  }, [setSidebarState, windowWidth])
+  }, [closeSidebar, windowWidth])
 
   return (
     <>
       <SidebarContainer open={sidebarState === 'open'}>
-        <CloseButton onClick={() => setSidebarState('close')}>{<X />}</CloseButton>
+        <CloseButton onClick={closeSidebar}>{<X />}</CloseButton>
         <Header>
           <Link to="/">
             <Logo alt="alephium" src={theme.name === 'light' ? logoLight : logoDark} />
@@ -93,13 +97,13 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
         <Navigation>
           <NavigationTitle>MENU</NavigationTitle>
           <Tabs>
-            <Tab to="/blocks" onClick={() => setSidebarState('close')}>
+            <Tab to="/blocks" onClick={closeSidebar}>
               <TabIcon src={blockIcon} alt="blocks" /> Blocks
             </Tab>
-            <Tab to="/addresses" onClick={() => setSidebarState('close')}>
+            <Tab to="/addresses" onClick={closeSidebar}>
               <TabIcon src={addressIcon} alt="addresses" /> Addresses
             </Tab>
-            <Tab to="/transactions" onClick={() => setSidebarState('close')}>
+            <Tab to="/transactions" onClick={closeSidebar}>
               <TabIcon src={transactionIcon} alt="transactions" /> Transactions
             </Tab>
           </Tabs>
@@ -109,7 +113,7 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
       <AnimatePresence>
         {sidebarState === 'open' && (
           <Backdrop
-            onClick={() => setSidebarState('close')}
+            onClick={closeSidebar}
             animate={{ opacity: 0.4 }}
             exit={{ opacity: 0 }}
             initial={{ opacity: 0 }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,7 +31,6 @@ import ThemeSwitcher, { StyledThemeSwitcher } from './ThemeSwitcher'
 import { GlobalContext } from '..'
 import Menu from './Menu'
 
-import { ReactComponent as AlephiumLogo } from '../images/alephium-logo-gradient-stroke.svg'
 import NetworkLogo from './NetworkLogo'
 
 export type SidebarState = 'open' | 'close'
@@ -203,7 +202,7 @@ const Header = styled.header`
   background-color: ${({ theme }) => theme.bgHighlight};
 
   @media ${deviceBreakPoints.tablet} {
-    margin-top: 50px;
+    padding-top: 50px;
   }
 `
 
@@ -211,10 +210,6 @@ const Tabs = styled.div`
   margin-top: 12px;
   display: flex;
   flex-direction: column;
-
-  @media ${deviceBreakPoints.tablet} {
-    margin-top: 30px;
-  }
 `
 
 const Navigation = styled.nav`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,6 +41,14 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
   const lastWindowWidth = useRef(windowWidth)
   const { setSidebarState, networkType } = useContext(GlobalContext)
 
+  const isMainnet = networkType === 'mainnet'
+
+  const switchToNetwork = (network: string) => {
+    if (networkType !== network) {
+      window.location.assign(isMainnet ? 'https://explorer.alephium.org' : `https://testnet.alephium.org`)
+    }
+  }
+
   useEffect(() => {
     if (windowWidth) {
       if (
@@ -65,21 +73,17 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
             <Logo alt="alephium" src={theme.name === 'light' ? logoLight : logoDark} />
           </Link>
           <NetworkMenu
-            label={networkType === 'mainnet' ? 'Mainnet' : 'Testnet'}
-            icon={networkType === 'mainnet' ? <NetworkLogo network="mainnet" /> : <NetworkLogo network="testnet" />}
+            label={isMainnet ? 'Mainnet' : 'Testnet'}
+            icon={isMainnet ? <NetworkLogo network="mainnet" /> : <NetworkLogo network="testnet" />}
             items={[
               {
                 text: 'Mainnet',
-                onClick: () => {
-                  window.location.assign('https://explorer.alephium.org')
-                },
+                onClick: () => switchToNetwork('mainnet'),
                 icon: <NetworkLogo network="mainnet" />
               },
               {
                 text: 'Testnet',
-                onClick: () => {
-                  window.location.assign('https://testnet.alephium.org')
-                },
+                onClick: () => switchToNetwork('testnet'),
                 icon: <NetworkLogo network="testnet" />
               }
             ]}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -64,40 +64,43 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
           <Link to="/">
             <Logo alt="alephium" src={theme.name === 'light' ? logoLight : logoDark} />
           </Link>
+          <NetworkMenu
+            label={networkType === 'mainnet' ? 'Mainnet' : 'Testnet'}
+            icon={networkType === 'mainnet' ? <AlephiumLogoMainnet /> : <AlephiumLogoTestnet />}
+            items={[
+              {
+                text: 'Mainnet',
+                onClick: () => {
+                  window.location.assign('https://explorer.alephium.org')
+                },
+                icon: <AlephiumLogoMainnet />
+              },
+              {
+                text: 'Testnet',
+                onClick: () => {
+                  window.location.assign('https://testnet.alephium.org')
+                },
+                icon: <AlephiumLogoTestnet />
+              }
+            ]}
+            direction="down"
+          />
         </Header>
-        <Tabs>
-          <Tab to="/blocks" onClick={() => setSidebarState('close')}>
-            <TabIcon src={blockIcon} alt="blocks" /> Blocks
-          </Tab>
-          <Tab to="/addresses" onClick={() => setSidebarState('close')}>
-            <TabIcon src={addressIcon} alt="addresses" /> Addresses
-          </Tab>
-          <Tab to="/transactions" onClick={() => setSidebarState('close')}>
-            <TabIcon src={transactionIcon} alt="transactions" /> Transactions
-          </Tab>
-        </Tabs>
+        <Navigation>
+          <NavigationTitle>MENU</NavigationTitle>
+          <Tabs>
+            <Tab to="/blocks" onClick={() => setSidebarState('close')}>
+              <TabIcon src={blockIcon} alt="blocks" /> Blocks
+            </Tab>
+            <Tab to="/addresses" onClick={() => setSidebarState('close')}>
+              <TabIcon src={addressIcon} alt="addresses" /> Addresses
+            </Tab>
+            <Tab to="/transactions" onClick={() => setSidebarState('close')}>
+              <TabIcon src={transactionIcon} alt="transactions" /> Transactions
+            </Tab>
+          </Tabs>
+        </Navigation>
         <ThemeSwitcher />
-        <NetworkMenu
-          label={networkType === 'mainnet' ? 'Mainnet' : 'Testnet'}
-          icon={networkType === 'mainnet' ? <AlephiumLogoMainnet /> : <AlephiumLogoTestnet />}
-          items={[
-            {
-              text: 'Mainnet',
-              onClick: () => {
-                window.location.assign('https://explorer.alephium.org')
-              },
-              icon: <AlephiumLogoMainnet />
-            },
-            {
-              text: 'Testnet',
-              onClick: () => {
-                window.location.assign('https://testnet.alephium.org')
-              },
-              icon: <AlephiumLogoTestnet />
-            }
-          ]}
-          direction={'up'}
-        />
       </SidebarContainer>
       <AnimatePresence>
         {sidebarState === 'open' && (
@@ -176,7 +179,7 @@ const SidebarContainer = styled.div<SidebarContainerProps>`
   ${StyledThemeSwitcher} {
     display: block;
     position: absolute;
-    bottom: 70px;
+    bottom: 25px;
     left: 25px;
   }
 
@@ -195,7 +198,8 @@ const SidebarContainer = styled.div<SidebarContainerProps>`
 
 const Header = styled.header`
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.bgHighlight};
 
   @media ${deviceBreakPoints.tablet} {
     margin-top: 50px;
@@ -206,11 +210,21 @@ const Tabs = styled.div`
   margin-top: 12px;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid ${({ theme }) => theme.borderPrimary};
 
   @media ${deviceBreakPoints.tablet} {
     margin-top: 30px;
   }
+`
+
+const Navigation = styled.nav`
+  margin-top: 25px;
+`
+
+const NavigationTitle = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  padding: 0 25px;
+  color: ${({ theme }) => theme.textSecondary};
 `
 
 const Tab = styled(NavLink)`
@@ -221,13 +235,11 @@ const Tab = styled(NavLink)`
   align-items: center;
   transition: all 0.15s ease;
   position: relative;
-  border-bottom: 1px solid ${({ theme }) => theme.borderPrimary};
   padding: 13px 20px;
 
   color: ${({ theme }) => theme.textSecondary};
   &.active {
     color: ${({ theme }) => theme.textPrimary};
-    background-color: ${({ theme }) => theme.bgPrimary};
 
     img {
       filter: none;
@@ -248,10 +260,7 @@ const TabIcon = styled.img`
 // Network switch
 
 const NetworkMenu = styled(Menu)`
-  position: absolute !important;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  border-bottom: 1px solid ${({ theme }) => theme.borderSecondary};
 `
 
 const AlephiumLogoMainnet = styled(AlephiumLogo)`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import { GlobalContext } from '..'
 import Menu from './Menu'
 
 import { ReactComponent as AlephiumLogo } from '../images/alephium-logo-gradient-stroke.svg'
+import NetworkLogo from './NetworkLogo'
 
 export type SidebarState = 'open' | 'close'
 
@@ -66,21 +67,21 @@ const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
           </Link>
           <NetworkMenu
             label={networkType === 'mainnet' ? 'Mainnet' : 'Testnet'}
-            icon={networkType === 'mainnet' ? <AlephiumLogoMainnet /> : <AlephiumLogoTestnet />}
+            icon={networkType === 'mainnet' ? <NetworkLogo network="mainnet" /> : <NetworkLogo network="testnet" />}
             items={[
               {
                 text: 'Mainnet',
                 onClick: () => {
                   window.location.assign('https://explorer.alephium.org')
                 },
-                icon: <AlephiumLogoMainnet />
+                icon: <NetworkLogo network="mainnet" />
               },
               {
                 text: 'Testnet',
                 onClick: () => {
                   window.location.assign('https://testnet.alephium.org')
                 },
-                icon: <AlephiumLogoTestnet />
+                icon: <NetworkLogo network="testnet" />
               }
             ]}
             direction="down"
@@ -260,20 +261,9 @@ const TabIcon = styled.img`
 // Network switch
 
 const NetworkMenu = styled(Menu)`
-  border-bottom: 1px solid ${({ theme }) => theme.borderSecondary};
-`
-
-const AlephiumLogoMainnet = styled(AlephiumLogo)`
-  path {
-    stroke-width: 18 !important;
-  }
-`
-
-const AlephiumLogoTestnet = styled(AlephiumLogo)`
-  path {
-    stroke-width: 18 !important;
-    stroke: ${({ theme }) => theme.textSecondary} !important;
-  }
+  border-width: 1px 0;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.borderSecondary};
 `
 
 export default Sidebar

--- a/src/style/styled.d.ts
+++ b/src/style/styled.d.ts
@@ -24,6 +24,8 @@ declare module 'styled-components' {
     borderSecondary: string
     borderHighlight: string
 
+    accentGradient: string
+
     tooltip: string
   }
 }

--- a/src/style/themes.ts
+++ b/src/style/themes.ts
@@ -22,6 +22,8 @@ export const darkTheme: DefaultTheme = {
   borderSecondary: '#27282d',
   borderHighlight: '#585962',
 
+  accentGradient: 'linear-gradient(200deg, #6510f7, #f76110) border-box',
+
   tooltip: 'black'
 }
 
@@ -44,6 +46,8 @@ export const lightTheme: DefaultTheme = {
   borderPrimary: '#e6e6e6',
   borderSecondary: '#e8e8e8',
   borderHighlight: '#D1D1D4',
+
+  accentGradient: 'linear-gradient(200deg, #6510f7, #f76110) border-box',
 
   tooltip: 'black'
 }

--- a/src/style/themes.ts
+++ b/src/style/themes.ts
@@ -38,11 +38,11 @@ export const lightTheme: DefaultTheme = {
 
   bgPrimary: 'white',
   bgSecondary: '#f7f7f7',
-  bgHighlight: 'rgba(0, 0, 0, 0.012)',
+  bgHighlight: 'rgba(0, 0, 0, 0.015)',
   bgHover: 'rgba(0, 0, 0, 0.01)',
 
   borderPrimary: '#e6e6e6',
-  borderSecondary: '#f2f2f2',
+  borderSecondary: '#e8e8e8',
   borderHighlight: '#D1D1D4',
 
   tooltip: 'black'


### PR DESCRIPTION
Fixes #35

- Put the network switch in the sidebar header, increasing its visibility.
- New NetworkLogo component, also more visible.
- Lighter navigation (no border)
- Refine styling + other tweaks.