### PR TITLE
Add Environment Variables to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN npm install serve -g --silent
 # add app
 COPY . ./
 
+ARG backend_url network_type
+
+ENV REACT_APP_BACKEND_URL=${backend_url}
+ENV REACT_APP_NETWORK_TYPE=${network_type}
+
 # create optimized production build
 RUN npm run build
 

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -5,7 +5,11 @@ CURRENT_COMMIT=`git rev-parse HEAD`
 CURRENT_TAG=`git tag --points-at HEAD`
 IMAGE_NAME=alephium/explorer:${CURRENT_COMMIT}
 
-docker build -t $IMAGE_NAME $DIR
+docker build \
+       --build-arg backend_url=${REACT_APP_BACKEND_URL:-http://localhost:9090} \
+       --build-arg network_type=${REACT_APP_NETWORK_TYPE:-mainnet} \
+       -t $IMAGE_NAME \
+       $DIR
 
 if [ ! -z $CURRENT_TAG ]
 then


### PR DESCRIPTION
Pass `REACT_APP_BACKEND_URL` and `REACT_APP_NETWORK_TYPE` environment variables when building docker image.
This enables explorer to be run as a docker image connecting to explorer backend running elsewhere.