### PR TITLE
Timestamp format switch

### DIFF
--- a/src/components/NetworkLogo.tsx
+++ b/src/components/NetworkLogo.tsx
@@ -17,8 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import styled from 'styled-components'
-
-import { NetworkType } from '..'
+import { NetworkType } from '../types/network'
 
 interface NetworkLogoProps {
   network: NetworkType

--- a/src/components/NetworkLogo.tsx
+++ b/src/components/NetworkLogo.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import styled from 'styled-components'
+
 import { NetworkType } from '../types/network'
 
 interface NetworkLogoProps {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,11 +30,10 @@ import logoDark from '../images/explorer-logo-dark.svg'
 import logoLight from '../images/explorer-logo-light.svg'
 import transactionIcon from '../images/transaction-icon.svg'
 import { deviceBreakPoints, deviceSizes } from '../style/globalStyles'
+import { SidebarState } from '../types/ui'
 import Menu from './Menu'
 import NetworkLogo from './NetworkLogo'
 import ThemeSwitcher, { StyledThemeSwitcher } from './ThemeSwitcher'
-
-export type SidebarState = 'open' | 'close'
 
 const Sidebar = ({ sidebarState }: { sidebarState: SidebarState }) => {
   const theme = useTheme()

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -220,8 +220,9 @@ const StyledTable = styled.table<TableProps>`
     }}
   }
 
-  td:nth-child(1) {
-    width: ${({ bodyOnly }) => (bodyOnly ? '27%' : 'auto')};
+  td {
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   tr td {

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -1,28 +1,59 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
 import dayjs from 'dayjs'
 import { MouseEvent, useContext } from 'react'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
+
 import { GlobalContext } from '..'
 
 dayjs.extend(localizedFormat)
 
 interface TimestampProps {
   timeInMs: number
-  fullPrecision?: boolean
+  forceHighPrecision?: boolean
 }
 
-const Timestamp = ({ timeInMs, fullPrecision = false }: TimestampProps) => {
+const Timestamp = ({ timeInMs, forceHighPrecision = false }: TimestampProps) => {
   const { timestampPrecisionMode, setTimestampPrecisionMode } = useContext(GlobalContext)
 
+  const isHighPrecision = timestampPrecisionMode === 'on' || forceHighPrecision
+
   const handleTimestampClick = (e: MouseEvent<HTMLSpanElement>) => {
-    if (fullPrecision) return
+    if (forceHighPrecision) return
     e.stopPropagation()
     setTimestampPrecisionMode(timestampPrecisionMode === 'on' ? 'off' : 'on')
   }
 
+  const highPrecisionTimestamp = dayjs(timeInMs).format('L LTS UTCZ')
+  const lowPrecisionTimestamp = dayjs().to(timeInMs)
+
   return (
-    <span onClick={handleTimestampClick}>
-      {timestampPrecisionMode === 'on' || fullPrecision ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
-    </span>
+    <>
+      <span
+        onClick={handleTimestampClick}
+        data-tip={`
+        ${isHighPrecision ? lowPrecisionTimestamp : highPrecisionTimestamp}
+        <br/>
+        (${isHighPrecision ? 'Click for human friendly format' : 'Click for higher precision'})`}
+        data-multiline
+      >
+        {isHighPrecision ? highPrecisionTimestamp : lowPrecisionTimestamp}
+      </span>
+    </>
   )
 }
 

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -44,17 +44,15 @@ const Timestamp = ({ timeInMs, forceHighPrecision = false }: TimestampProps) => 
   const lowPrecisionTimestamp = dayjs().to(timeInMs)
 
   return (
-    <>
-      <span
-        onClick={handleTimestampClick}
-        data-tip={`
+    <span
+      onClick={handleTimestampClick}
+      data-tip={`
         ${isHighPrecision ? lowPrecisionTimestamp : highPrecisionTimestamp}
         ${!forceHighPrecision ? '<br/>(Click to change format)' : ''}`}
-        data-multiline
-      >
-        {isHighPrecision ? highPrecisionTimestamp : lowPrecisionTimestamp}
-      </span>
-    </>
+      data-multiline
+    >
+      {isHighPrecision ? highPrecisionTimestamp : lowPrecisionTimestamp}
+    </span>
   )
 }
 

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs'
+import { MouseEvent } from 'react'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
+import { useStateWithLocalStorage } from '../utils/hooks'
+
+dayjs.extend(localizedFormat)
+
+interface TimestampProps {
+  timeInMs: number
+}
+
+const Timestamp = ({ timeInMs }: TimestampProps) => {
+  const [precisionMode, setPrecisionMode] = useStateWithLocalStorage<'on' | 'off'>('timestampPrecisionMode', 'off')
+
+  const handleTimestampClick = (e: MouseEvent<HTMLSpanElement>) => {
+    e.stopPropagation()
+    setPrecisionMode(precisionMode === 'on' ? 'off' : 'on')
+  }
+
+  return (
+    <span onClick={handleTimestampClick}>
+      {precisionMode === 'on' ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
+    </span>
+  )
+}
+
+export default Timestamp

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -49,8 +49,7 @@ const Timestamp = ({ timeInMs, forceHighPrecision = false }: TimestampProps) => 
         onClick={handleTimestampClick}
         data-tip={`
         ${isHighPrecision ? lowPrecisionTimestamp : highPrecisionTimestamp}
-        <br/>
-        (Click to change format)`}
+        ${!forceHighPrecision ? '<br/>(Click to change format)' : ''}`}
         data-multiline
       >
         {isHighPrecision ? highPrecisionTimestamp : lowPrecisionTimestamp}

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -7,19 +7,21 @@ dayjs.extend(localizedFormat)
 
 interface TimestampProps {
   timeInMs: number
+  fullPrecision?: boolean
 }
 
-const Timestamp = ({ timeInMs }: TimestampProps) => {
+const Timestamp = ({ timeInMs, fullPrecision = false }: TimestampProps) => {
   const { timestampPrecisionMode, setTimestampPrecisionMode } = useContext(GlobalContext)
 
   const handleTimestampClick = (e: MouseEvent<HTMLSpanElement>) => {
+    if (fullPrecision) return
     e.stopPropagation()
     setTimestampPrecisionMode(timestampPrecisionMode === 'on' ? 'off' : 'on')
   }
 
   return (
     <span onClick={handleTimestampClick}>
-      {timestampPrecisionMode === 'on' ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
+      {timestampPrecisionMode === 'on' || fullPrecision ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
     </span>
   )
 }

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -17,6 +17,7 @@
 import dayjs from 'dayjs'
 import { MouseEvent, useContext } from 'react'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
+import ReactTooltip from 'react-tooltip'
 
 import { GlobalContext } from '..'
 
@@ -36,6 +37,7 @@ const Timestamp = ({ timeInMs, forceHighPrecision = false }: TimestampProps) => 
     if (forceHighPrecision) return
     e.stopPropagation()
     setTimestampPrecisionMode(timestampPrecisionMode === 'on' ? 'off' : 'on')
+    ReactTooltip.hide()
   }
 
   const highPrecisionTimestamp = dayjs(timeInMs).format('L LTS UTCZ')
@@ -48,7 +50,7 @@ const Timestamp = ({ timeInMs, forceHighPrecision = false }: TimestampProps) => 
         data-tip={`
         ${isHighPrecision ? lowPrecisionTimestamp : highPrecisionTimestamp}
         <br/>
-        (${isHighPrecision ? 'Click for human friendly format' : 'Click for higher precision'})`}
+        (Click to change format)`}
         data-multiline
       >
         {isHighPrecision ? highPrecisionTimestamp : lowPrecisionTimestamp}

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
-import { MouseEvent } from 'react'
+import { MouseEvent, useContext } from 'react'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
-import { useStateWithLocalStorage } from '../utils/hooks'
+import { GlobalContext } from '..'
 
 dayjs.extend(localizedFormat)
 
@@ -10,16 +10,16 @@ interface TimestampProps {
 }
 
 const Timestamp = ({ timeInMs }: TimestampProps) => {
-  const [precisionMode, setPrecisionMode] = useStateWithLocalStorage<'on' | 'off'>('timestampPrecisionMode', 'off')
+  const { timestampPrecisionMode, setTimestampPrecisionMode } = useContext(GlobalContext)
 
   const handleTimestampClick = (e: MouseEvent<HTMLSpanElement>) => {
     e.stopPropagation()
-    setPrecisionMode(precisionMode === 'on' ? 'off' : 'on')
+    setTimestampPrecisionMode(timestampPrecisionMode === 'on' ? 'off' : 'on')
   }
 
   return (
     <span onClick={handleTimestampClick}>
-      {precisionMode === 'on' ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
+      {timestampPrecisionMode === 'on' ? dayjs(timeInMs).format('L LTS UTCZ') : dayjs().to(timeInMs)}
     </span>
   )
 }

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -1,22 +1,24 @@
-// Copyright 2018 The Alephium Authors
-// This file is part of the alephium project.
-//
-// The library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the library. If not, see <http://www.gnu.org/licenses/>.
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 import dayjs from 'dayjs'
-import { MouseEvent, useContext } from 'react'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
+import { MouseEvent, useContext } from 'react'
 import ReactTooltip from 'react-tooltip'
 
 import { GlobalContext } from '..'

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -24,10 +24,14 @@ interface TooltipProps {
   id?: string
 }
 
-const Tooltip: FC<TooltipProps> = ({ id }) => {
+const Tooltip: FC<TooltipProps> = ({ id, children }) => {
   const theme = useTheme()
 
-  return <ReactTooltip backgroundColor={theme.tooltip} id={id} />
+  return (
+    <ReactTooltip backgroundColor={theme.tooltip} id={id}>
+      {children}
+    </ReactTooltip>
+  )
 }
 
 export default Tooltip

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ import styled, { ThemeProvider } from 'styled-components'
 
 import NotificationBar from './components/NotificationBar'
 import SearchBar from './components/SearchBar'
-import Sidebar, { SidebarState } from './components/Sidebar'
+import Sidebar from './components/Sidebar'
 import { StyledThemeSwitcher } from './components/ThemeSwitcher'
 import AddressInfoSection from './sections/AddressInfoSection'
 import AddressesSection from './sections/AdressesSection'
@@ -43,32 +43,16 @@ import TransactionsSection from './sections/TransactionsSection'
 import * as serviceWorker from './serviceWorker'
 import GlobalStyle, { deviceBreakPoints } from './style/globalStyles'
 import { darkTheme, lightTheme, ThemeType } from './style/themes'
+import { GlobalContextInterface } from './types/context'
+import { OnOff } from './types/generics'
+import { NetworkType, networkTypes } from './types/network'
+import { SidebarState, SnackbarMessage } from './types/ui'
 import { AlephClient, createClient } from './utils/client'
 import { useStateWithLocalStorage } from './utils/hooks'
 import { isElectron } from './utils/misc'
 import { ScrollToTop } from './utils/routing'
 
-const networkTypes = ['testnet', 'mainnet'] as const
-export type NetworkType = typeof networkTypes[number]
-
-interface SnackbarMessage {
-  text: string
-  type: 'info' | 'alert' | 'success'
-  duration?: number
-}
-
-interface GlobalContext {
-  client: AlephClient | undefined
-  explorerClient: ExplorerClient | undefined
-  networkType: NetworkType | undefined
-  currentTheme: ThemeType
-  sidebarState: 'open' | 'close'
-  setSidebarState: (state: SidebarState) => void
-  switchTheme: (arg0: ThemeType) => void
-  setSnackbarMessage: (message: SnackbarMessage) => void
-}
-
-export const GlobalContext = React.createContext<GlobalContext>({
+export const GlobalContext = React.createContext<GlobalContextInterface>({
   client: undefined,
   explorerClient: undefined,
   networkType: undefined,
@@ -76,7 +60,9 @@ export const GlobalContext = React.createContext<GlobalContext>({
   sidebarState: 'open',
   setSidebarState: () => null,
   switchTheme: () => null,
-  setSnackbarMessage: () => null
+  setSnackbarMessage: () => null,
+  timestampPrecisionMode: 'off',
+  setTimestampPrecisionMode: () => null
 })
 
 /* Customize data format accross the app */
@@ -107,6 +93,10 @@ const App = () => {
   const [networkType, setNetworkType] = useState<NetworkType>()
   const [snackbarMessage, setSnackbarMessage] = useState<SnackbarMessage | undefined>()
   const [sidebarState, setSidebarState] = useState<SidebarState>('close')
+  const [timestampPrecisionMode, setTimestampPrecisionMode] = useStateWithLocalStorage<OnOff>(
+    'timestampPrecisionMode',
+    'off'
+  )
 
   const contentRef = useRef(null)
 
@@ -158,7 +148,9 @@ const App = () => {
             switchTheme: setThemeName as (arg0: ThemeType) => void,
             sidebarState: 'close',
             setSidebarState: setSidebarState,
-            setSnackbarMessage
+            setSnackbarMessage,
+            timestampPrecisionMode,
+            setTimestampPrecisionMode
           }}
         >
           <MainContainer>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,16 +72,16 @@ dayjs.updateLocale('en', {
   relativeTime: {
     future: 'in %s',
     past: '%s ago',
-    s: 'a few secs',
-    m: 'a min',
+    s: 'A few secs',
+    m: 'A min',
     mm: '%d mins',
-    h: 'an hour',
+    h: 'An hour',
     hh: '%d hours',
-    d: 'a day',
+    d: 'A day',
     dd: '%d days',
-    M: 'a month',
+    M: 'A month',
     MM: '%d months',
-    y: 'a year',
+    y: 'A year',
     yy: '%d years'
   }
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,7 @@ import * as serviceWorker from './serviceWorker'
 import GlobalStyle, { deviceBreakPoints } from './style/globalStyles'
 import { darkTheme, lightTheme, ThemeType } from './style/themes'
 import { AlephClient, createClient } from './utils/client'
+import { useStateWithLocalStorage } from './utils/hooks'
 import { isElectron } from './utils/misc'
 import { ScrollToTop } from './utils/routing'
 
@@ -230,19 +231,6 @@ const SnackbarManager = ({ message }: { message: SnackbarMessage | undefined }) 
       </AnimatePresence>
     </SnackbarManagerContainer>
   )
-}
-
-/* Custom hooks */
-// Local storage hook
-
-function useStateWithLocalStorage<T>(localStorageKey: string, defaultValue: T) {
-  const [value, setValue] = React.useState(localStorage.getItem(localStorageKey) || defaultValue)
-
-  React.useEffect(() => {
-    localStorage.setItem(localStorageKey, value as string)
-  }, [localStorageKey, value])
-
-  return [value, setValue]
 }
 
 /* Styles */

--- a/src/sections/AddressInfoSection.tsx
+++ b/src/sections/AddressInfoSection.tsx
@@ -45,14 +45,11 @@ import {
   TableHeader,
   TDStyle
 } from '../components/Table'
+import Timestamp from '../components/Timestamp'
 import usePageNumber from '../hooks/usePageNumber'
 import useTableDetailsState from '../hooks/useTableDetailsState'
 import { getHumanReadableError } from '../utils/api'
-<<<<<<< HEAD
 import { APIResp } from '../utils/client'
-=======
-import Timestamp from '../components/Timestamp'
->>>>>>> 78c8b2e (Centralise globally used types + add timestampPrecisionMode in GlobalContext)
 
 dayjs.extend(relativeTime)
 

--- a/src/sections/AddressInfoSection.tsx
+++ b/src/sections/AddressInfoSection.tsx
@@ -48,7 +48,11 @@ import {
 import usePageNumber from '../hooks/usePageNumber'
 import useTableDetailsState from '../hooks/useTableDetailsState'
 import { getHumanReadableError } from '../utils/api'
+<<<<<<< HEAD
 import { APIResp } from '../utils/client'
+=======
+import Timestamp from '../components/Timestamp'
+>>>>>>> 78c8b2e (Centralise globally used types + add timestampPrecisionMode in GlobalContext)
 
 dayjs.extend(relativeTime)
 
@@ -236,7 +240,7 @@ const AddressTransactionRow: FC<AddressTransactionRowProps> = ({ transaction, ad
         <td>
           <TightLink to={`/transactions/${t.hash}`} text={t.hash} maxWidth="120px" />
         </td>
-        <td>{(t.timestamp && dayjs().to(t.timestamp)) || '-'}</td>
+        <td>{(t.timestamp && <Timestamp timeInMs={t.timestamp} />) || '-'}</td>
         <td>
           <Badge type={isOut ? 'minus' : 'plus'} content={isOut ? 'To' : 'From'} />
         </td>

--- a/src/sections/BlockInfoSection.tsx
+++ b/src/sections/BlockInfoSection.tsx
@@ -148,7 +148,7 @@ const BlockInfoSection = () => {
                   <tr>
                     <td>Timestamp</td>
                     <td>
-                      <Timestamp timeInMs={blockInfo.data.timestamp} fullPrecision />
+                      <Timestamp timeInMs={blockInfo.data.timestamp} forceHighPrecision />
                     </td>
                   </tr>
                 </TableBody>

--- a/src/sections/BlockInfoSection.tsx
+++ b/src/sections/BlockInfoSection.tsx
@@ -161,7 +161,7 @@ const BlockInfoSection = () => {
                     <>
                       <Table main hasDetails scrollable>
                         <TableHeader
-                          headerTitles={['', 'Hash', 'Inputs', '', 'Outputs', 'Total amount', '']}
+                          headerTitles={['', 'Hash', 'Inputs', '', 'Outputs', 'Total Amount', '']}
                           columnWidths={['35px', '150px', '120px', '50px', '120px', '90px', '30px']}
                           textAlign={['left', 'left', 'left', 'left', 'left', 'right', 'left']}
                         />

--- a/src/sections/BlockInfoSection.tsx
+++ b/src/sections/BlockInfoSection.tsx
@@ -17,7 +17,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Transaction } from 'alephium-js/dist/api/api-explorer'
-import dayjs from 'dayjs'
 import { ArrowRight } from 'lucide-react'
 import { FC, useContext, useEffect, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
@@ -43,6 +42,7 @@ import {
   TableHeader,
   TDStyle
 } from '../components/Table'
+import Timestamp from '../components/Timestamp'
 import usePageNumber from '../hooks/usePageNumber'
 import useTableDetailsState from '../hooks/useTableDetailsState'
 import transactionIcon from '../images/transaction-icon.svg'
@@ -147,7 +147,9 @@ const BlockInfoSection = () => {
                   </tr>
                   <tr>
                     <td>Timestamp</td>
-                    <td>{dayjs(blockInfo.data.timestamp).format('MM/DD/YYYY HH:mm:ss')}</td>
+                    <td>
+                      <Timestamp timeInMs={blockInfo.data.timestamp} fullPrecision />
+                    </td>
                   </tr>
                 </TableBody>
               </Table>

--- a/src/sections/BlockSection.tsx
+++ b/src/sections/BlockSection.tsx
@@ -35,6 +35,7 @@ import blockIcon from '../images/block-icon.svg'
 import { BlockList } from '../types/api'
 import { APIResp } from '../utils/client'
 import { useInterval } from '../utils/hooks'
+import Timestamp from '../components/Timestamp'
 
 dayjs.extend(relativeTime)
 
@@ -117,7 +118,9 @@ const BlockSection = () => {
                   <td>
                     <TightLink to={`blocks/${b.hash}`} text={b.hash} maxWidth="150px" />
                   </td>
-                  <td>{dayjs().to(b.timestamp)}</td>
+                  <td>
+                    <Timestamp timeInMs={b.timestamp} />
+                  </td>
                   <td>{b.height}</td>
                   <td>{b.txNumber}</td>
                   <td>

--- a/src/sections/BlockSection.tsx
+++ b/src/sections/BlockSection.tsx
@@ -30,12 +30,12 @@ import PageSwitch from '../components/PageSwitch'
 import Section from '../components/Section'
 import SectionTitle from '../components/SectionTitle'
 import { Table, TableBody, TableHeader, TDStyle } from '../components/Table'
+import Timestamp from '../components/Timestamp'
 import usePageNumber from '../hooks/usePageNumber'
 import blockIcon from '../images/block-icon.svg'
 import { BlockList } from '../types/api'
 import { APIResp } from '../utils/client'
 import { useInterval } from '../utils/hooks'
-import Timestamp from '../components/Timestamp'
 
 dayjs.extend(relativeTime)
 

--- a/src/sections/TransactionInfoSection.tsx
+++ b/src/sections/TransactionInfoSection.tsx
@@ -17,7 +17,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Output, Transaction, TransactionLike, UOutput } from 'alephium-js/dist/api/api-explorer'
-import dayjs from 'dayjs'
 import { Check } from 'lucide-react'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
@@ -31,6 +30,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import Section from '../components/Section'
 import SectionTitle from '../components/SectionTitle'
 import { HighlightedCell, Table, TableBody } from '../components/Table'
+import Timestamp from '../components/Timestamp'
 import { APIResp } from '../utils/client'
 import { useInterval } from '../utils/hooks'
 
@@ -131,7 +131,9 @@ const TransactionInfoSection = () => {
                 {isTxConfirmed(txInfo.data) && txInfo.data.timestamp && (
                   <tr>
                     <td>Timestamp</td>
-                    <td>{dayjs(txInfo.data.timestamp).format('MM/DD/YYYY HH:mm:ss')}</td>
+                    <td>
+                      <Timestamp timeInMs={txInfo.data.timestamp} fullPrecision />
+                    </td>
                   </tr>
                 )}
                 {isTxConfirmed(txInfo.data) && (

--- a/src/sections/TransactionInfoSection.tsx
+++ b/src/sections/TransactionInfoSection.tsx
@@ -132,7 +132,7 @@ const TransactionInfoSection = () => {
                   <tr>
                     <td>Timestamp</td>
                     <td>
-                      <Timestamp timeInMs={txInfo.data.timestamp} fullPrecision />
+                      <Timestamp timeInMs={txInfo.data.timestamp} forceHighPrecision />
                     </td>
                   </tr>
                 )}

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,20 +1,23 @@
-// Copyright 2018 The Alephium Authors
-// This file is part of the alephium project.
-//
-// The library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the library. If not, see <http://www.gnu.org/licenses/>.
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 import { ExplorerClient } from 'alephium-js'
+
 import { ThemeType } from '../style/themes'
 import { AlephClient } from '../utils/client'
 import { OnOff } from './generics'

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,19 @@
+import { ExplorerClient } from 'alephium-js'
+import { ThemeType } from '../style/themes'
+import { AlephClient } from '../utils/client'
+import { OnOff } from './generics'
+import { NetworkType } from './network'
+import { SidebarState, SnackbarMessage } from './ui'
+
+export interface GlobalContextInterface {
+  client: AlephClient | undefined
+  explorerClient: ExplorerClient | undefined
+  networkType: NetworkType | undefined
+  currentTheme: ThemeType
+  sidebarState: 'open' | 'close'
+  setSidebarState: (state: SidebarState) => void
+  switchTheme: (arg0: ThemeType) => void
+  setSnackbarMessage: (message: SnackbarMessage) => void
+  timestampPrecisionMode: OnOff
+  setTimestampPrecisionMode: (status: OnOff) => void
+}

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,3 +1,19 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
 import { ExplorerClient } from 'alephium-js'
 import { ThemeType } from '../style/themes'
 import { AlephClient } from '../utils/client'

--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,17 +1,19 @@
-// Copyright 2018 The Alephium Authors
-// This file is part of the alephium project.
-//
-// The library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the library. If not, see <http://www.gnu.org/licenses/>.
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 export type OnOff = 'on' | 'off'

--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,1 +1,17 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
 export type OnOff = 'on' | 'off'

--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,0 +1,1 @@
+export type OnOff = 'on' | 'off'

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,0 +1,3 @@
+export const networkTypes = ['testnet', 'mainnet'] as const
+
+export type NetworkType = typeof networkTypes[number]

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,3 +1,19 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
 export const networkTypes = ['testnet', 'mainnet'] as const
 
 export type NetworkType = typeof networkTypes[number]

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,18 +1,20 @@
-// Copyright 2018 The Alephium Authors
-// This file is part of the alephium project.
-//
-// The library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the library. If not, see <http://www.gnu.org/licenses/>.
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 export const networkTypes = ['testnet', 'mainnet'] as const
 

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,0 +1,7 @@
+export interface SnackbarMessage {
+  text: string
+  type: 'info' | 'alert' | 'success'
+  duration?: number
+}
+
+export type SidebarState = 'open' | 'close'

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,18 +1,20 @@
-// Copyright 2018 The Alephium Authors
-// This file is part of the alephium project.
-//
-// The library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the library. If not, see <http://www.gnu.org/licenses/>.
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 export interface SnackbarMessage {
   text: string

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,3 +1,19 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
 export interface SnackbarMessage {
   text: string
   type: 'info' | 'alert' | 'success'

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -42,8 +42,8 @@ export function useStateWithLocalStorage<T extends string>(localStorageKey: stri
   const [value, setValue] = useState(localStorage.getItem(localStorageKey) || defaultValue)
 
   useEffect(() => {
-    localStorage.setItem(localStorageKey, value as T)
+    localStorage.setItem(localStorageKey, value)
   }, [localStorageKey, value])
 
-  return [value, setValue] as const
+  return [value as T, setValue] as const
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export function useInterval(callback: () => void, delay: number, shouldPause = false) {
   const savedCallback = useRef<() => void>(() => null)
@@ -36,4 +36,14 @@ export function useInterval(callback: () => void, delay: number, shouldPause = f
       return () => clearInterval(id)
     }
   }, [delay, shouldPause])
+}
+
+export function useStateWithLocalStorage<T extends string>(localStorageKey: string, defaultValue: T) {
+  const [value, setValue] = useState(localStorage.getItem(localStorageKey) || defaultValue)
+
+  useEffect(() => {
+    localStorage.setItem(localStorageKey, value as T)
+  }, [localStorageKey, value])
+
+  return [value, setValue] as const
 }


### PR DESCRIPTION
Fixes #48

Note1: the tooltip is not refreshed when clicking on the timestamp to change the format. This is a minor issue that I mitigated by hiding the tooltip on click. Calling ReactTooltip.rebuild()` didn't help. We could have forced parent remounting, but didn't want to make this overcomplicated.

Note2: Imports order is wrong in several places + some file headers are still missing. I'll add the proper lint configuration & plugins in a separate PR.