### PR TITLE
Fix browser upgrade msg when BigInt not supported

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,6 @@ import ReactDOM from 'react-dom'
 import { HashRouter as Router } from 'react-router-dom'
 
 import NotificationBar from './components/NotificationBar'
-import { GlobalContextProvider } from './contexts/global'
 import * as serviceWorker from './serviceWorker'
 import { isFlexGapSupported } from './utils/browserSupport'
 
@@ -43,14 +42,16 @@ if (browserIsOld) {
   )
 } else {
   import('./App').then(({ default: App }) => {
-    ReactDOM.render(
-      <Router>
-        <GlobalContextProvider>
-          <App />
-        </GlobalContextProvider>
-      </Router>,
-      document.getElementById('root')
-    )
+    import('./contexts/global').then(({ GlobalContextProvider }) => {
+      ReactDOM.render(
+        <Router>
+          <GlobalContextProvider>
+            <App />
+          </GlobalContextProvider>
+        </Router>,
+        document.getElementById('root')
+      )
+    })
   })
 }
 


### PR DESCRIPTION
When running the app on an iPhone 11 Safari 13 through Browserstack, I noticed that our detection mechanism of whether `BigInt` is supported is broken:
```
ReferenceError: Can't find variable: BigInt
```

The reason is that we import the global context (which itself imports the sdk, which references `BigInt` in `lib/constants.ts`) BEFORE the BigInt detection mechanism.

This PR fixes this problem, importing the global context after the `BigInt` detection mechanism.