### PR TITLE
Add GH workflow to deploy on demand to testnet

### DIFF
--- a/.github/workflows/publish_to_testnet.yml
+++ b/.github/workflows/publish_to_testnet.yml
@@ -1,0 +1,33 @@
+name: Publish to testnet
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: eu-central-1
+  AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID }}
+  AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+  REACT_APP_BACKEND_URL=https://testnet-backend.alephium.org
+  REACT_APP_NETWORK_TYPE=testnet
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 17
+
+    - name: Build frontend
+      run: npm install && npm run build
+
+    - name: Sync files to S3
+      run: aws s3 sync ./build/ s3://$AWS_BUCKET_NAME --acl public-read --delete --cache-control max-age=604800
+
+    - name: Notify CloudFront about the changes
+      run: aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --paths "/*"

--- a/.github/workflows/publish_to_testnet.yml
+++ b/.github/workflows/publish_to_testnet.yml
@@ -9,8 +9,8 @@ env:
   AWS_DEFAULT_REGION: eu-central-1
   AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID }}
   AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-  REACT_APP_BACKEND_URL=https://testnet-backend.alephium.org
-  REACT_APP_NETWORK_TYPE=testnet
+  REACT_APP_BACKEND_URL: https://testnet-backend.alephium.org
+  REACT_APP_NETWORK_TYPE: testnet
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a workflow to deploy on demand to the testnet. The branch to build and deploy can be select when triggering the deployment.