### PR TITLE
Optimise waves using less points and lower fps

### DIFF
--- a/src/components/Wave/WaveEntity.ts
+++ b/src/components/Wave/WaveEntity.ts
@@ -36,8 +36,11 @@ class WaveEntity {
       return
     }
 
-    // TODO: Don't draw a line for each pixel of the curve (optimization)
-    for (let i = 0; i < width; i++) {
+    const standardPpi = 96
+    const pointsPerInch = 15
+    const pointSpacing = standardPpi / pointsPerInch
+
+    for (let i = 0; i < width; i += pointSpacing) {
       const wave1 = Math.sin(i * this.waveLength[0] - frequency)
       const wave2 = Math.sin(i * this.waveLength[1] - frequency)
       const wave3 = Math.sin(i * this.waveLength[2] - frequency)

--- a/src/components/Wave/Waves.tsx
+++ b/src/components/Wave/Waves.tsx
@@ -32,15 +32,23 @@ const Waves = () => {
   const { width } = useWindowSize()
 
   let t = 0
+  let f = 0
 
   useAnimationFrame((deltaTime) => {
-    t = t + (deltaTime * 6) / 100000
+    t = t + deltaTime / 1000.0
+    f += 1
+
+    // 60 fps / 8 ~= 8fps
+    // Given the speed of the animation this is sufficient to look smooth
+    if (f != 8) return
+    f = 0
+
     const { innerWidth } = window
 
     if (canvasContextRef.current) {
       canvasContextRef.current.clearRect(0, 0, innerWidth, staticHeight)
       Object.entries(waves).forEach((w) => {
-        w[1].draw(canvasContextRef.current as CanvasRenderingContext2D, innerWidth, staticHeight, t)
+        w[1].draw(canvasContextRef.current as CanvasRenderingContext2D, innerWidth, staticHeight, t / 20.0)
       })
     } else {
       let ctx


### PR DESCRIPTION
Brings the CPU usage down from ~70% peak and ~33% average to ~33% peak and ~7-10% average cpu usage

Resolves https://github.com/alephium/explorer/issues/109