### PR TITLE
Greatly simplify download handling

### DIFF
--- a/src/modals/ExportAddressTXsModal.tsx
+++ b/src/modals/ExportAddressTXsModal.tsx
@@ -42,55 +42,17 @@ const ExportAddressTXsModal = ({ addressHash, onClose, ...props }: ExportAddress
 
   const [timePeriodValue, setTimePeriodValue] = useState<TimePeriodValue>('24h')
 
-  const getCSVFile = useCallback(async () => {
-    onClose()
+  const downloadLink = `${client?.baseUrl}/addresses/${addressHash}/export-transactions/csv?fromTs=${timePeriods[timePeriodValue].from}&toTs=${timePeriods[timePeriodValue].to}`
 
+  const handleDownloadStart = () => {
     setSnackbarMessage({
-      text: "Your CSV is being compiled in the background (don't close the explorer)...",
-      type: 'info',
-      Icon: <LoadingSpinner size={20} style={{ color: 'inherit' }} />,
-      duration: -1
+      text: 'Your CSV file is being downloaded.',
+      type: 'success',
+      Icon: <Check size={14} />
     })
 
-    try {
-      const res = await client?.addresses.getAddressesAddressExportTransactionsCsv(
-        addressHash,
-        {
-          fromTs: timePeriods[timePeriodValue].from,
-          toTs: timePeriods[timePeriodValue].to
-        },
-        {
-          // Don't forget to define the format field in order to show errors! (cf. swagger-typescript-api code)
-          format: 'text' // We expect a CSV. Careful: errors would be returned as a string as well.
-        }
-      )
-
-      if (!res?.data) throw 'Something wrong happened while fetching the data.'
-
-      startCSVFileDownload(res.data, `${addressHash}__${timePeriodValue}__${dayjs().format('DD-MM-YYYY')}`)
-
-      setSnackbarMessage({
-        text: 'Your CSV has been successfully downloaded.',
-        type: 'success',
-        Icon: <Check size={14} />
-      })
-    } catch (e) {
-      console.error(e)
-      const parsedError = e as APIError
-
-      if (isString(parsedError.error)) {
-        parsedError.error = JSON.parse(parsedError.error as string) // we received a "text" format, need to parse the JSON
-      }
-
-      setSnackbarMessage(undefined) // remove previously set message
-
-      setSnackbarMessage({
-        text: getHumanReadableError(parsedError, 'Problem while downloading the CSV file'),
-        type: 'alert',
-        duration: 5000
-      })
-    }
-  }, [addressHash, client?.addresses, onClose, setSnackbarMessage, timePeriodValue])
+    onClose()
+  }
 
   return (
     <Modal maxWidth={550} onClose={onClose} {...props}>
@@ -109,9 +71,11 @@ const ExportAddressTXsModal = ({ addressHash, onClose, ...props }: ExportAddress
         />
       </Selects>
       <FooterButton>
-        <Button accent big onClick={getCSVFile}>
-          Export
-        </Button>
+        <a href={downloadLink} download onClick={handleDownloadStart}>
+          <Button accent big>
+            Export
+          </Button>
+        </a>
       </FooterButton>
     </Modal>
   )
@@ -166,18 +130,6 @@ const timePeriods: Record<TimePeriodValue, { from: number; to: number }> = {
     to: now.subtract(1, 'year').endOf('year').valueOf()
   },
   thisYear: { from: now.startOf('year').valueOf(), to: now.valueOf() }
-}
-
-const startCSVFileDownload = (csvContent: string, fileName: string) => {
-  const url = URL.createObjectURL(new Blob([csvContent], { type: 'text/csv' }))
-  const a = document.createElement('a')
-  a.style.display = 'none'
-  a.href = url
-  a.download = fileName
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  window.URL.revokeObjectURL(url)
 }
 
 export default styled(ExportAddressTXsModal)`

--- a/src/modals/ExportAddressTXsModal.tsx
+++ b/src/modals/ExportAddressTXsModal.tsx
@@ -16,16 +16,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { APIError, getHumanReadableError } from '@alephium/sdk'
 import dayjs from 'dayjs'
-import { isString } from 'lodash'
 import { Check } from 'lucide-react'
-import { ComponentProps, useCallback, useState } from 'react'
+import { ComponentProps, useState } from 'react'
 import styled from 'styled-components'
 
 import Button from '@/components/Buttons/Button'
 import HighlightedHash from '@/components/HighlightedHash'
-import LoadingSpinner from '@/components/LoadingSpinner'
 import Modal from '@/components/Modal/Modal'
 import Select, { SelectListItem } from '@/components/Select'
 import { useGlobalContext } from '@/contexts/global'


### PR DESCRIPTION
Only disadvantage of this approach is that I can't specify the downloaded file name, because to the [`same-origin` requirement](https://stackoverflow.com/a/45368364).

But @tdroxler is now setting a default name in `1.11.1`, albeit a quite complex one with timestamps in millisecond. 

This should only be released after backend `1.11.1` is running on prod.