### PR TITLE
[workflow] Publish to mainnet

### DIFF
--- a/.github/workflows/publish_to_mainnet.yml
+++ b/.github/workflows/publish_to_mainnet.yml
@@ -1,0 +1,33 @@
+name: Publish to mainnet
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_MAINNET }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_MAINNET }}
+  AWS_DEFAULT_REGION: eu-central-1
+  AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID_MAINNET }}
+  AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME_MAINNET }}
+  VITE_BACKEND_URL: https://backend-v111.mainnet.alephium.org
+  VITE_NETWORK_TYPE: mainnet
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Build frontend
+        run: npm ci && npm run build && node docker/init-server-data.js
+
+      - name: Sync files to S3
+        run: aws s3 sync ./build/ s3://$AWS_BUCKET_NAME --acl public-read --delete --cache-control max-age=604800
+
+      - name: Notify CloudFront about the changes
+        run: aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --paths "/*"


### PR DESCRIPTION
This workflow looks the same than "Publish to testnet" but has the mainnet environment variable injected to deploy the explorer frontent to the mainnet bucket.