### PR TITLE
Fix multiple output display in tx table

### DIFF
--- a/src/pages/TransactionInfoPage.tsx
+++ b/src/pages/TransactionInfoPage.tsx
@@ -206,17 +206,18 @@ const TransactionInfoPage = () => {
               {isTxConfirmed(txInfo) && (
                 <TableRow>
                   <span>Outputs</span>
-
-                  {txInfo.outputs
-                    ? txInfo.outputs.map((v, i) => (
-                        <AddressLink
-                          address={v.address}
-                          key={i}
-                          amount={BigInt(v.attoAlphAmount)}
-                          txHashRef={v.spent}
-                        />
-                      ))
-                    : '-'}
+                  <div>
+                    {txInfo.outputs
+                      ? txInfo.outputs.map((v, i) => (
+                          <AddressLink
+                            address={v.address}
+                            key={i}
+                            amount={BigInt(v.attoAlphAmount)}
+                            txHashRef={v.spent}
+                          />
+                        ))
+                      : '-'}
+                  </div>
                 </TableRow>
               )}
               <TableRow>


### PR DESCRIPTION
@mvaivre, this `Children.map` bit us in the 🍑 after all... When using the `TableRow` it's not obvious that its implementation will loop over the children and add each in a `td`... I guess that's why you removed the `width: 65%`, and now that I added it back it created this issue. Wrapping all outputs with a `div` fixes the problem in this case where only the first output is being displayed.