### PR TITLE
Ensure compatibility with explorer-backend v1.13.0

### DIFF
--- a/.github/workflows/publish_to_mainnet.yml
+++ b/.github/workflows/publish_to_mainnet.yml
@@ -9,7 +9,7 @@ env:
   AWS_DEFAULT_REGION: eu-central-1
   AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID_MAINNET }}
   AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME_MAINNET }}
-  VITE_BACKEND_URL: https://backend-v111.mainnet.alephium.org
+  VITE_BACKEND_URL: https://backend-v113.mainnet.alephium.org
   VITE_NETWORK_TYPE: mainnet
 
 jobs:

--- a/.github/workflows/publish_to_testnet.yml
+++ b/.github/workflows/publish_to_testnet.yml
@@ -9,7 +9,7 @@ env:
   AWS_DEFAULT_REGION: eu-central-1
   AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID }}
   AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-  VITE_BACKEND_URL: https://backend-v111.testnet.alephium.org
+  VITE_BACKEND_URL: https://backend-v113.testnet.alephium.org
   VITE_NETWORK_TYPE: testnet
 
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "alephium-explorer",
       "version": "1.5.5-rc.0",
       "dependencies": {
-        "@alephium/sdk": "0.5.0",
+        "@alephium/sdk": "^0.6.0-rc.4",
         "apexcharts": "^3.35.0",
         "colord": "^2.9.3",
         "dayjs": "^1.10.7",
@@ -71,9 +71,9 @@
       "dev": true
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-GcuaKU4TOUBeRy1UNvOpYPGjQ2zF2fY7mbHr6/wC28IkSbQgmAzEbIsc0y82w0opdkQZQRCk/hJeQmShuI6iIA==",
+      "version": "0.6.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.0-rc.4.tgz",
+      "integrity": "sha512-/3h8fZlbAGUCFn5AmTzhZvcGgN5qzK5UUulvJxpW0EfVXjIVdUxTWRegSyldYaJhXTJAAk+QzlWn47eFbTqX7A==",
       "dependencies": {
         "base-x": "^4.0.0",
         "bcfg": "~0.1.6",
@@ -7170,9 +7170,9 @@
       "dev": true
     },
     "@alephium/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-GcuaKU4TOUBeRy1UNvOpYPGjQ2zF2fY7mbHr6/wC28IkSbQgmAzEbIsc0y82w0opdkQZQRCk/hJeQmShuI6iIA==",
+      "version": "0.6.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.0-rc.4.tgz",
+      "integrity": "sha512-/3h8fZlbAGUCFn5AmTzhZvcGgN5qzK5UUulvJxpW0EfVXjIVdUxTWRegSyldYaJhXTJAAk+QzlWn47eFbTqX7A==",
       "requires": {
         "base-x": "^4.0.0",
         "bcfg": "~0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "alephium-explorer",
       "version": "1.5.5-rc.0",
       "dependencies": {
-        "@alephium/sdk": "^0.6.0-rc.4",
+        "@alephium/sdk": "0.6.1",
         "apexcharts": "^3.35.0",
         "colord": "^2.9.3",
         "dayjs": "^1.10.7",
@@ -71,9 +71,9 @@
       "dev": true
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.6.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.0-rc.4.tgz",
-      "integrity": "sha512-/3h8fZlbAGUCFn5AmTzhZvcGgN5qzK5UUulvJxpW0EfVXjIVdUxTWRegSyldYaJhXTJAAk+QzlWn47eFbTqX7A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-ewmio50Q7n/fRcAXM8eXm7XAycQOMd50JhbgVL/MhEl/QU3NvbsTMu4tAPOv0FqUJVQ+Wq/NugF+l6WHJ1JmvA==",
       "dependencies": {
         "base-x": "^4.0.0",
         "bcfg": "~0.1.6",
@@ -7170,9 +7170,9 @@
       "dev": true
     },
     "@alephium/sdk": {
-      "version": "0.6.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.0-rc.4.tgz",
-      "integrity": "sha512-/3h8fZlbAGUCFn5AmTzhZvcGgN5qzK5UUulvJxpW0EfVXjIVdUxTWRegSyldYaJhXTJAAk+QzlWn47eFbTqX7A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-ewmio50Q7n/fRcAXM8eXm7XAycQOMd50JhbgVL/MhEl/QU3NvbsTMu4tAPOv0FqUJVQ+Wq/NugF+l6WHJ1JmvA==",
       "requires": {
         "base-x": "^4.0.0",
         "bcfg": "~0.1.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "/",
   "dependencies": {
-    "@alephium/sdk": "0.5.0",
+    "@alephium/sdk": "^0.6.0-rc.4",
     "apexcharts": "^3.35.0",
     "colord": "^2.9.3",
     "dayjs": "^1.10.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "/",
   "dependencies": {
-    "@alephium/sdk": "^0.6.0-rc.4",
+    "@alephium/sdk": "0.6.1",
     "apexcharts": "^3.35.0",
     "colord": "^2.9.3",
     "dayjs": "^1.10.7",

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -33,13 +33,16 @@ const Amount = ({ value, className, fadeDecimals, showFullPrecision = false }: A
   let fractionalPart = ''
 
   if (value !== undefined) {
-    const amountParts = formatAmountForDisplay(value, showFullPrecision).split('.')
+    const amountParts = formatAmountForDisplay({ amount: value, fullPrecision: showFullPrecision }).split('.')
     integralPart = amountParts[0]
     fractionalPart = amountParts[1]
   }
 
   return (
-    <span className={className} data-tip={value ? `${formatAmountForDisplay(BigInt(value), true)} א` : null}>
+    <span
+      className={className}
+      data-tip={value ? `${formatAmountForDisplay({ amount: BigInt(value), fullPrecision: true })} א` : null}
+    >
       {value !== undefined ? (
         fadeDecimals ? (
           <>


### PR DESCRIPTION
@mvaivre I cherry-picked your commit and added 2 of my own. I know that your #165 PR was taking care of it, but I didn't want to rash merging something that might need more testing. This PR was done so that @killerwhile can retire the explorer-backend v1.11 endpoints which explorer mainnet is still using.

I've tested everything that I could think of locally using `https://backend-v113.testnet.alephium.org` as the backend URL and it works fine