### PR TITLE
Trigger testnet & mainnet deployments with tags

### DIFF
--- a/.github/workflows/publish_to_mainnet.yml
+++ b/.github/workflows/publish_to_mainnet.yml
@@ -1,6 +1,8 @@
 name: Publish to mainnet
 
 on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]']
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish_to_testnet.yml
+++ b/.github/workflows/publish_to_testnet.yml
@@ -1,6 +1,8 @@
 name: Publish to testnet
 
 on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]', 'v[0-9]+.[0-9]+.[0-9]-rc.[0-9]+']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
@mvaivre @killerwhile I look forward to hear your thoughts on this proposal.

## Problem
How do I know what is running on mainnet and on testnet? How do I know what was last deployed? The actions logs don't show me this information when deploying a branch and not a tag, and even if it's a tag that is deployed, I have to dig that out from the logs of the last executed action.

## Proposal 1
Similarly to how we trigger the "sign and release" workflow by pushing a tag that matches a regex in the desktop wallet, I am proposing that our "deploy to [mainnet|testnet]" workflows also get triggered by tags. Specifically, I propose:
- mainnet workflow gets triggered by tags that match the pattern `v1.2.3`
- testnet workflow gets triggereed by tags that match the above patter, but also `v1.2.3-rc.0`

### Concerns
It's true that the "sign and release" workflow is less impactful. It creates a draft release. Nothing gets published until I explicitly edit the draft release and publish it. Whereas in the case of the explorer, things get deployed on public services. 

## Proposal 2
We figure out how to restrict the manual triggering amongst the tag options (aka: not be able to trigger the workflows on a branch but only on a tag. This doc page might have more info on how to do that: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

---

On top of the above approaches, I think it'd be useful to have a small `v1.2.3` text somewhere at the footer of the app:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1579899/224027467-51da78d5-7fdc-476b-a296-3b5385b13f1c.png">


---

I am open to your feedback and to discuss my approach and/or alternative approaches!