### PR TITLE
Fix error handling in transaction page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,8 @@ dayjs.updateLocale('en', {
   }
 })
 
+export const numberOfAPIRetries = 10
+
 const App = () => {
   const { theme } = useSettings()
   const navigate = useNavigate()
@@ -72,7 +74,7 @@ const App = () => {
       queries: {
         refetchOnWindowFocus: false,
         retryDelay: (attemptIndex) => Math.pow(2, attemptIndex) * 1000,
-        retry: 10,
+        retry: numberOfAPIRetries,
         staleTime: 10000, // default ms before cache data is considered stale
         cacheTime: ONE_DAY_MS
       }

--- a/src/pages/TransactionInfoPage.tsx
+++ b/src/pages/TransactionInfoPage.tsx
@@ -34,6 +34,7 @@ import styled from 'styled-components'
 
 import { queries } from '@/api'
 import { useAssetsMetadata } from '@/api/assets/assetsHooks'
+import { numberOfAPIRetries } from '@/App'
 import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
 import Badge from '@/components/Badge'
@@ -60,7 +61,6 @@ const TransactionInfoPage = () => {
   const { id } = useParams<ParamTypes>()
   const isAppVisible = usePageVisibility()
   const { displaySnackbar } = useSnackbar()
-  const retryNum = 10 //as defined in App.tsx
 
   const previousTransactionData = useRef<Transaction | undefined>()
 
@@ -78,7 +78,7 @@ const TransactionInfoPage = () => {
         isAppVisible &&
         (!previousTransactionData.current || !isTxConfirmed(previousTransactionData.current)) &&
         error.includes('not found') &&
-        num < retryNum
+        num < numberOfAPIRetries
       )
     }
   })


### PR DESCRIPTION
Resolves: https://github.com/alephium/explorer/issues/230

In case of a not found it was fine to keep retrying for 10 times to get the transaction as it could just be not yet synced by the explorer-backend or it's in between the mempool and the confirmed state.

If we receive any other error it's not worth retrying as it will always we wrong.

![image](https://github.com/alephium/explorer/assets/2979182/fc313b86-fbc4-4fce-9400-0eee79fe17da)
![image](https://github.com/alephium/explorer/assets/2979182/b517dcaf-dbe3-48b9-985a-9722b7ca5b48)
![image](https://github.com/alephium/explorer/assets/2979182/665212e1-6d47-43e0-abda-70c155acd1ce)
